### PR TITLE
Permissive regex for conda env names from nb_conda_kernels 

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: nb_conda
-  version: "0.1.3"
+  version: "0.1.4"
 
 build:
   number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}

--- a/nb_conda/_version.py
+++ b/nb_conda/_version.py
@@ -1,2 +1,2 @@
-version_info = (0, 1, 3)
+version_info = (0, 1, 4)
 __version__ = '.'.join(map(str, version_info))

--- a/nb_conda/nbextension/static/main.js
+++ b/nb_conda/nbextension/static/main.js
@@ -1,4 +1,5 @@
 define(function(require) {
+    "use strict";
     var $ = require('jquery');
     var IPython = require('base/js/namespace');
     var models = require('./models');
@@ -65,7 +66,7 @@ define(function(require) {
                         // names of the form 'Python [env_name]' or 'R [env_name]'
                         var kernel_name = IPython.notebook.kernel.name;
 
-                        m = /\[(\w+)\]/.exec(kernel_name);
+                        var m = /\[(.+)\]$/.exec(kernel_name);
                         if(m) {
                             env_name = m[1];
                         }

--- a/nb_conda/setup.py
+++ b/nb_conda/setup.py
@@ -3,6 +3,6 @@ from os.path import abspath, dirname, join
 
 setup(
     name="nb_conda",
-    version="0.1.3",
+    version="0.1.4",
     static=join(abspath(dirname(__file__)), 'nbextension', 'static')
 )


### PR DESCRIPTION
This changes the behavior of environment name extraction from the nb_conda_kernels name/kernel string. Previously couldn't match normal-looking names like `my-env`, but certainly not crazy ones like `my-env[lastest] new changes`, which is a totally valid environment name (except for post-link scripts that don't enclose paths in quotes).

also, 
- `use strict`, because always, 
- and `var m` to avoid global scope leaking