### PR TITLE
Fix missing re.match() argument

### DIFF
--- a/nb_conda/envmanager.py
+++ b/nb_conda/envmanager.py
@@ -98,7 +98,7 @@ class EnvManager(LoggingConfigurable):
             self.log.warn('[nb_conda] JSON parse fail:\n%s', err)
 
         # try to remove bad lines
-        lines = [line for line in lines if re.match(JSONISH_RE)]
+        lines = [line for line in lines if re.match(JSONISH_RE, line)]
 
         try:
             return json.loads('\n'.join(lines))


### PR DESCRIPTION
re.match requires 2 arguments
1) the regex to perform the match
2) the string to match against