### PR TITLE
Fix ConfigParser and package version parsing errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
         mv ../conda/conda-bld .
     - name: Upload the build artifact
       if: github.event_name == 'push'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         # By uploading to the same artifact we can download all of the packages
         # and upload them all to anaconda.org in a single job

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest,ubuntu-latest,windows-latest]
-        pyver: [2.7,3.6,3.7,3.8]
+        pyver: [3.8, 3.9, "3.10", "3.11", "3.12"]
     steps:
     - name: Retrieve the source code
       uses: actions/checkout@v2

--- a/nb_conda/handlers.py
+++ b/nb_conda/handlers.py
@@ -6,20 +6,16 @@
 
 # Tornado get and post handlers often have different args from their base class
 # methods.
-
 import json
 import os
 import re
-
+import subprocess
 from subprocess import Popen
 from tempfile import TemporaryFile
 
-from pkg_resources import parse_version
+from notebook.base.handlers import APIHandler, json_errors
 from notebook.utils import url_path_join as ujoin
-from notebook.base.handlers import (
-    APIHandler,
-    json_errors,
-)
+from packaging.version import InvalidVersion, Version
 from tornado import web
 
 from .envmanager import EnvManager, package_map
@@ -155,6 +151,22 @@ class CondaSearcher(object):
         self.conda_process = None
         self.conda_temp = None
 
+    def _parse_version(self, version_str):
+        """Handle R-style and year-based versions"""
+        # Convert R package versions like "1.8_4" to "1.8.4"
+        version_str = version_str.replace('_', '.')
+
+        # Handle year-based versions like "2023d" -> "2023.4"
+        if re.match(r'^\d{4}[a-z]$', version_str):
+            letter = version_str[-1]
+            number = ord(letter) - ord('a') + 1
+            version_str = f"{version_str[:-1]}.{number}"
+
+        try:
+            return Version(version_str)
+        except InvalidVersion:
+            return None
+
     def list_available(self, handler=None):
         """
         List the available conda packages by kicking off a background
@@ -164,7 +176,7 @@ class CondaSearcher(object):
         will be returned (this will be a dict containing error information).
         TODO - break up this method.
         """
-        self.log = handler.log
+        self.log = handler.log if handler else None
 
         if self.conda_process is not None:
             # already running, check for completion
@@ -194,13 +206,13 @@ class CondaSearcher(object):
                     max_version_entry = None
 
                     for entry in entries:
-                        version = parse_version(entry.get('version', ''))
-
-                        if max_version is None or version > max_version:
+                        version = self._parse_version(entry.get('version', ''))
+                        if version is not None and (max_version is None or version > max_version):
                             max_version = version
                             max_version_entry = entry
 
-                    packages.append(max_version_entry)
+                    if max_version_entry:
+                        packages.append(max_version_entry)
 
                 return sorted(packages, key=lambda entry: entry.get('name'))
 

--- a/versioneer.py
+++ b/versioneer.py
@@ -1557,7 +1557,6 @@ def get_cmdclass():
 
     if "cx_Freeze" in sys.modules:  # cx_freeze enabled?
         from cx_Freeze.dist import build_exe as _build_exe
-
         # nczeczulin reports that py2exe won't like the pep440-style string
         # as FILEVERSION, but it can be used for PRODUCTVERSION, e.g.
         # setup(console=[{

--- a/versioneer.py
+++ b/versioneer.py
@@ -276,11 +276,7 @@ https://creativecommons.org/publicdomain/zero/1.0/ .
 
 """
 
-from __future__ import print_function
-try:
-    import configparser
-except ImportError:
-    import ConfigParser as configparser
+import configparser
 import errno
 import json
 import os
@@ -339,9 +335,9 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):
@@ -1561,6 +1557,7 @@ def get_cmdclass():
 
     if "cx_Freeze" in sys.modules:  # cx_freeze enabled?
         from cx_Freeze.dist import build_exe as _build_exe
+
         # nczeczulin reports that py2exe won't like the pep440-style string
         # as FILEVERSION, but it can be used for PRODUCTVERSION, e.g.
         # setup(console=[{


### PR DESCRIPTION
This PR updates two main items:

1. With Python 3.12+, SafeConfigParser is no longer available in the configparser library. This PR replaces use of it with versioneer with ConfigParser, and replaces readfp with read_file.
2. Getting a list of packages when opening the extension was failing with the below error. I updated the version parsing to be compatible with R and date package versions.
3. Upgrades actions/upload-artifact v2 to v4, since CI wouldn't run with the old version

```
[E 2025-02-11 09:13:05.669 ServerApp] Uncaught exception GET /conda/packages/available?=1739282942008 (127.0.0.1)
    HTTPServerRequest(protocol='http', host='localhost:8889', method='GET', uri='/conda/packages/available?=1739282942008', version='HTTP/1.1', remote_ip='127.0.0.1')
    Traceback (most recent call last):
      File "/Users/dyeaw/miniconda3/envs/conda_nb/lib/python3.9/site-packages/tornado/web.py", line 1788, in _execute
        result = method(*self.path_args, self.path_kwargs)
      File "/Users/dyeaw/miniconda3/envs/conda_nb/lib/python3.9/site-packages/tornado/web.py", line 3301, in wrapper
        return method(self, *args, kwargs)
      File "/Users/dyeaw/miniconda3/envs/conda_nb/lib/python3.9/site-packages/notebook/base/handlers.py", line 782, in wrapper
        return method(self, *args, kwargs)
      File "/Users/dyeaw/miniconda3/envs/conda_nb/lib/python3.9/site-packages/nb_conda/handlers.py", line 230, in get
        data = searcher.list_available(self)
      File "/Users/dyeaw/miniconda3/envs/conda_nb/lib/python3.9/site-packages/nb_conda/handlers.py", line 197, in list_available
        version = parse_version(entry.get('version', ''))
      File "/Users/dyeaw/miniconda3/envs/conda_nb/lib/python3.9/site-packages/packaging/version.py", line 202, in init**
        raise InvalidVersion(f"Invalid version: {version!r}")
    packaging.version.InvalidVersion: Invalid version: 'custom'
```